### PR TITLE
Add 50fps fallback

### DIFF
--- a/reflex_curses/reflex.py
+++ b/reflex_curses/reflex.py
@@ -585,7 +585,7 @@ class Keybinds:
 
                 # prefer 60fps streams, but fallback if they aren't available
                 if quality[-1] == 'p':
-                    quality = f"{quality}60,{quality}"
+                    quality = f"{quality}60,{quality}50,{quality}"
 
                 cmd = (
                     f"setsid "  # detach process from terminal


### PR DESCRIPTION
On rare occasions a 50fps option is available instead of 60fps
Example VOD with 50fps: https://www.twitch.tv/videos/1199479060